### PR TITLE
Add GitHub CI pipeline workflow to run RSpec tests

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,34 @@
+name: RSpec Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [catalog, crawler, tg_bot]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+
+      - name: Install dependencies
+        run: |
+          cd apps/${{ matrix.app }}
+          bundle install
+
+      - name: Run RSpec tests
+        run: |
+          cd apps/${{ matrix.app }}
+          bundle exec rspec

--- a/Procfile.test
+++ b/Procfile.test
@@ -1,2 +1,3 @@
 catalog_test: cd ./apps/catalog && bundle exec rspec
 crawler_test: cd ./apps/crawler && bundle exec rspec
+tg_bot_test: cd ./apps/tg_bot && bundle exec rspec


### PR DESCRIPTION
Add a GitHub CI pipeline workflow to automate running RSpec tests for each application in the `apps` directory.

* **Procfile.test**
  - Add a command to run RSpec tests for `apps/tg_bot`.

* **.github/workflows/rspec.yml**
  - Create a GitHub Actions workflow file to run RSpec tests for each application in the `apps` directory.
  - Use a matrix strategy to run tests for `apps/catalog`, `apps/crawler`, and `apps/tg_bot` in parallel.
  - Trigger the workflow on every push and pull request to the `main` branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dm1try/rent_assistant?shareId=33433d6a-e621-438f-a73c-b9de8fd01bbc).