### PR TITLE
Fix RSpec runs by ensuring the test database is properly set up

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -28,6 +28,11 @@ jobs:
           cd apps/${{ matrix.app }}
           bundle install
 
+      - name: Set up test database
+        run: |
+          cd apps/${{ matrix.app }}
+          bundle exec sequel -m db/migrations sqlite://db/${{ matrix.app }}_test.db
+
       - name: Run RSpec tests
         run: |
           cd apps/${{ matrix.app }}

--- a/apps/catalog/spec/spec_helper.rb
+++ b/apps/catalog/spec/spec_helper.rb
@@ -103,4 +103,9 @@ RSpec.configure do |config|
   config.around(:each) do |example|
     DB.transaction(rollback: :always, auto_savepoint: true) { example.run }
   end
+
+  config.before(:suite) do
+    Sequel.extension :migration
+    Sequel::Migrator.run(DB, 'db/migrations')
+  end
 end

--- a/apps/crawler/spec/spec_helper.rb
+++ b/apps/crawler/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     # and `failure_message` of custom matchers include text for helper methods
     # defined using `chain`, e.g.:
     #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
+    #     # => "be bigger than 2"
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -110,5 +110,10 @@ RSpec.configure do |config|
 =end
   config.around(:each) do |example|
     DB.transaction(rollback: :always, auto_savepoint: true) { example.run }
+  end
+
+  config.before(:suite) do
+    Sequel.extension :migration
+    Sequel::Migrator.run(DB, 'db/migrations')
   end
 end

--- a/apps/tg_bot/spec/spec_helper.rb
+++ b/apps/tg_bot/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
     # and `failure_message` of custom matchers include text for helper methods
     # defined using `chain`, e.g.:
     #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
+    #     # => "be bigger than 2"
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -100,5 +100,10 @@ RSpec.configure do |config|
 =end
   config.around(:each) do |example|
     DB.transaction(rollback: :always, auto_savepoint: true) { example.run }
+  end
+
+  config.before(:suite) do
+    Sequel.extension :migration
+    Sequel::Migrator.run(DB, 'db/migrations')
   end
 end


### PR DESCRIPTION
Add commands to create and migrate the test database before running the RSpec suite.

* **apps/catalog/spec/spec_helper.rb**
  - Add `config.before(:suite)` block to create and migrate the test database using Sequel.

* **apps/crawler/spec/spec_helper.rb**
  - Add `config.before(:suite)` block to create and migrate the test database using Sequel.

* **apps/tg_bot/spec/spec_helper.rb**
  - Add `config.before(:suite)` block to create and migrate the test database using Sequel.

* **.github/workflows/rspec.yml**
  - Add a step to set up the test database before running the RSpec tests.
  - Include commands to create and migrate the test databases for each application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dm1try/rent_assistant?shareId=212fce90-9101-43f8-9da6-26f6a8a6f27e).