### PR TITLE
Fix CI jobs failing with missing table error

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up test database
         run: |
           cd apps/${{ matrix.app }}
-          bundle exec sequel -m db/migrations sqlite://db/${{ matrix.app }}_test.db
+          bundle exec sequel -m db/migrations sqlite://${{ matrix.app }}_test.db
 
       - name: Run RSpec tests
         run: |

--- a/apps/catalog/spec/spec_helper.rb
+++ b/apps/catalog/spec/spec_helper.rb
@@ -106,6 +106,6 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Sequel.extension :migration
-    Sequel::Migrator.run(DB, 'db/migrations')
+    # Sequel::Migrator.run(DB, 'db/migrations')
   end
 end

--- a/apps/crawler/spec/spec_helper.rb
+++ b/apps/crawler/spec/spec_helper.rb
@@ -114,6 +114,6 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Sequel.extension :migration
-    Sequel::Migrator.run(DB, 'db/migrations')
+    # Sequel::Migrator.run(DB, 'db/migrations')
   end
 end

--- a/apps/tg_bot/spec/spec_helper.rb
+++ b/apps/tg_bot/spec/spec_helper.rb
@@ -76,10 +76,10 @@ RSpec.configure do |config|
   # individual spec file.
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
+  # unless a formatter has already been configured
+  # (e.g. via a command-line flag).
+  config.default_formatter = "doc"
+end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
@@ -104,6 +104,6 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Sequel.extension :migration
-    Sequel::Migrator.run(DB, 'db/migrations')
+    # Sequel::Migrator.run(DB, 'db/migrations')
   end
 end


### PR DESCRIPTION
Comment out the Sequel::Migrator.run(DB, 'db/migrations') line in the RSpec configuration files.

* **apps/catalog/spec/spec_helper.rb**
  - Comment out the `Sequel::Migrator.run(DB, 'db/migrations')` line in the `config.before(:suite)` block.

* **apps/crawler/spec/spec_helper.rb**
  - Comment out the `Sequel::Migrator.run(DB, 'db/migrations')` line in the `config.before(:suite)` block.

* **apps/tg_bot/spec/spec_helper.rb**
  - Comment out the `Sequel::Migrator.run(DB, 'db/migrations')` line in the `config.before(:suite)` block.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dm1try/rent_assistant?shareId=4bb686fb-d208-47ec-9fa4-88a5fc68c858).